### PR TITLE
Add option to show text side-by-side

### DIFF
--- a/public/templates/demo/paragraph.yml
+++ b/public/templates/demo/paragraph.yml
@@ -14,3 +14,11 @@ edits:
     icon: fa-magnifying-glass
     enable_input: true
     enable_output: true
+
+# When working with long texts, you might prefer a horizontal layout to minimize scrolling.
+# The following options can be freely combined.
+
+# display:
+# - side-by-side         # shows text and editor next to each other
+# - text-side-by-side    # shows source and target next to each other
+# - disable-lines        # disables lines between annotations which can be distracting

--- a/public/templates/demo/paragraph.yml
+++ b/public/templates/demo/paragraph.yml
@@ -3,6 +3,16 @@
 # more information related to the annotation.
 
 # ========================================================================================
+
+# When working with long texts, you might prefer a horizontal layout to minimize scrolling.
+# The following options can be freely combined.
+
+# display:
+# - side-by-side         # shows text and editor next to each other
+# - text-side-by-side    # shows source and target next to each other
+# - disable-lines        # disables lines between annotations which can be distracting
+
+# ========================================================================================
 # ========================================================================================
 
 template_name: demo
@@ -14,11 +24,3 @@ edits:
     icon: fa-magnifying-glass
     enable_input: true
     enable_output: true
-
-# When working with long texts, you might prefer a horizontal layout to minimize scrolling.
-# The following options can be freely combined.
-
-# display:
-# - side-by-side         # shows text and editor next to each other
-# - text-side-by-side    # shows source and target next to each other
-# - disable-lines        # disables lines between annotations which can be distracting

--- a/src/assets/css/editor.css
+++ b/src/assets/css/editor.css
@@ -13,7 +13,7 @@
 .builder {
     display: grid;
     grid-template-columns: 1fr 0fr 1fr;
-    height: 100%; 
+    height: 100%;
 }
 
 .header h3, .header h2 {
@@ -255,7 +255,7 @@
     color: rgb(65, 65, 65);
     text-decoration: underline;
 }
-  
+
 
 .cite-overlay pre {
     background-color: #f6f6f6;
@@ -279,7 +279,7 @@
 
 /* Select box options */
 .submit-container option:checked {
-    background-color: #dbdbdb; 
+    background-color: #dbdbdb;
 }
 option:checked:after {
     content: attr(title);
@@ -300,7 +300,7 @@ select:focus{
     text-align:center;
     margin: 16px auto 40px auto;
 }
-  
+
 .tabs{
     font-size: 16px;
     font-weight: bold;
@@ -312,7 +312,7 @@ select:focus{
     border-radius:50px;
     position:relative;
 }
-  
+
 .tabs a{
     text-decoration:none;
     color: #777;
@@ -323,15 +323,15 @@ select:focus{
     z-index:1;
     transition-duration:0.2s;
 }
-  
+
 .tabs a.active{
     color:#fff;
 }
-  
+
 .tabs a i{
     margin-right:5px;
-} 
-  
+}
+
 .tabs .selector{
     height:100%;
     display:inline-block;
@@ -342,7 +342,7 @@ select:focus{
     border-radius:50px;
     transition-duration:0.2s;
     transition-timing-function: cubic-bezier(0.43, -0.09, 0.51, 1.13);
-    
+
     background: #181818;
 }
 
@@ -364,11 +364,11 @@ select:focus{
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.5); 
+    background-color: rgba(0, 0, 0, 0.5);
     pointer-events: none;
 }
 .data-upload-container-disabled.grayed {
-    filter: grayscale(100%); 
+    filter: grayscale(100%);
 }
 
 .aws-creds {

--- a/src/assets/css/editor.css
+++ b/src/assets/css/editor.css
@@ -13,7 +13,7 @@
 .builder {
     display: grid;
     grid-template-columns: 1fr 0fr 1fr;
-    height: 100%;
+    height: 100%; 
 }
 
 .header h3, .header h2 {
@@ -255,7 +255,7 @@
     color: rgb(65, 65, 65);
     text-decoration: underline;
 }
-
+  
 
 .cite-overlay pre {
     background-color: #f6f6f6;
@@ -279,7 +279,7 @@
 
 /* Select box options */
 .submit-container option:checked {
-    background-color: #dbdbdb;
+    background-color: #dbdbdb; 
 }
 option:checked:after {
     content: attr(title);
@@ -300,7 +300,7 @@ select:focus{
     text-align:center;
     margin: 16px auto 40px auto;
 }
-
+  
 .tabs{
     font-size: 16px;
     font-weight: bold;
@@ -312,7 +312,7 @@ select:focus{
     border-radius:50px;
     position:relative;
 }
-
+  
 .tabs a{
     text-decoration:none;
     color: #777;
@@ -323,15 +323,15 @@ select:focus{
     z-index:1;
     transition-duration:0.2s;
 }
-
+  
 .tabs a.active{
     color:#fff;
 }
-
+  
 .tabs a i{
     margin-right:5px;
-}
-
+} 
+  
 .tabs .selector{
     height:100%;
     display:inline-block;
@@ -342,7 +342,7 @@ select:focus{
     border-radius:50px;
     transition-duration:0.2s;
     transition-timing-function: cubic-bezier(0.43, -0.09, 0.51, 1.13);
-
+    
     background: #181818;
 }
 
@@ -364,11 +364,11 @@ select:focus{
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: rgba(0, 0, 0, 0.5); 
     pointer-events: none;
 }
 .data-upload-container-disabled.grayed {
-    filter: grayscale(100%);
+    filter: grayscale(100%); 
 }
 
 .aws-creds {

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -8,13 +8,13 @@
 .container-extra-space {
     margin-bottom: 40vh;
 }
-  
+
 .card {
     border-radius: 4px;
     margin-left: auto;
     margin-right: auto;
 }
-  
+
 .card-body {
     margin-left: auto!important;
     margin-right: auto!important;
@@ -76,7 +76,7 @@
 }
 
 .editor-container {
-    max-width: 1200px;
+    max-width: 800px;
     margin: auto;
 }
 
@@ -97,7 +97,7 @@
     height: 100%;
     background-color: rgba(0, 0, 0, .4);
 }
-  
+
 .card-body .modal {
     position: absolute;
     max-width: 700px;
@@ -118,16 +118,16 @@
 }
 
 ::-webkit-scrollbar {
-  width: 10px; 
+  width: 10px;
 }
 ::-webkit-scrollbar-track {
-  background: #f1f1f1; 
+  background: #f1f1f1;
 }
 ::-webkit-scrollbar-thumb {
-  background: #888; 
+  background: #888;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: #555; 
+  background: #555;
 }
 #sandbox {
     overflow-y: scroll;
@@ -207,9 +207,9 @@
     position: relative;
 }
 
-.circle:hover { 
+.circle:hover {
     border: 1.1px solid black;
-    transform: scale(1.15); 
+    transform: scale(1.15);
 }
 
 .circle:hover .tooltiptext {
@@ -219,7 +219,7 @@
 
 .circle-active {
     border: 1.1px solid black !important;
-    transform: scale(1.15); 
+    transform: scale(1.15);
 }
 
 .circle-bookmark {
@@ -328,14 +328,14 @@ span.middleside {
 }
 
 .spinner {
-    border: 16px solid #f3f3f3; 
-    border-top: 16px solid #181818; 
+    border: 16px solid #f3f3f3;
+    border-top: 16px solid #181818;
     border-radius: 50%;
     width: 120px;
     height: 120px;
     animation: spin 2s linear infinite;
 }
-  
+
 .spinner-container {
     z-index: 1;
     position: absolute;
@@ -343,7 +343,7 @@ span.middleside {
     left: 50%;
     transform: translate(-50%, -50%);
 }
-  
+
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
@@ -377,7 +377,6 @@ span.middleside {
     grid-template-columns: repeat(2, 1fr);
     grid-gap: 32px;
     grid-auto-flow: column;
-    max-height: 97vh;
 }
 
 .annotation-adjacent, .selection-adjacent {
@@ -426,7 +425,7 @@ span.middleside {
 /* span#target-sentence {
     line-height: 1.7;
     font-size: 10.5pt;
-} 
+}
 .edit-box {
     width: 165px;
 }
@@ -452,4 +451,3 @@ span.middleside {
 .column-severity label {
     padding: 6px !important;
 } */
-

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -76,7 +76,7 @@
 }
 
 .editor-container {
-    max-width: 800px;
+    max-width: 1200px;
     margin: auto;
 }
 

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -76,7 +76,7 @@
 }
 
 .editor-container {
-    max-width: 1200px;
+    max-width: 800px;
     margin: auto;
 }
 
@@ -452,4 +452,3 @@ span.middleside {
 .column-severity label {
     padding: 6px !important;
 } */
-

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -8,13 +8,13 @@
 .container-extra-space {
     margin-bottom: 40vh;
 }
-
+  
 .card {
     border-radius: 4px;
     margin-left: auto;
     margin-right: auto;
 }
-
+  
 .card-body {
     margin-left: auto!important;
     margin-right: auto!important;
@@ -76,7 +76,7 @@
 }
 
 .editor-container {
-    max-width: 800px;
+    max-width: 1200px;
     margin: auto;
 }
 
@@ -97,7 +97,7 @@
     height: 100%;
     background-color: rgba(0, 0, 0, .4);
 }
-
+  
 .card-body .modal {
     position: absolute;
     max-width: 700px;
@@ -118,16 +118,16 @@
 }
 
 ::-webkit-scrollbar {
-  width: 10px;
+  width: 10px; 
 }
 ::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: #f1f1f1; 
 }
 ::-webkit-scrollbar-thumb {
-  background: #888;
+  background: #888; 
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: #555;
+  background: #555; 
 }
 #sandbox {
     overflow-y: scroll;
@@ -207,9 +207,9 @@
     position: relative;
 }
 
-.circle:hover {
+.circle:hover { 
     border: 1.1px solid black;
-    transform: scale(1.15);
+    transform: scale(1.15); 
 }
 
 .circle:hover .tooltiptext {
@@ -219,7 +219,7 @@
 
 .circle-active {
     border: 1.1px solid black !important;
-    transform: scale(1.15);
+    transform: scale(1.15); 
 }
 
 .circle-bookmark {
@@ -328,14 +328,14 @@ span.middleside {
 }
 
 .spinner {
-    border: 16px solid #f3f3f3;
-    border-top: 16px solid #181818;
+    border: 16px solid #f3f3f3; 
+    border-top: 16px solid #181818; 
     border-radius: 50%;
     width: 120px;
     height: 120px;
     animation: spin 2s linear infinite;
 }
-
+  
 .spinner-container {
     z-index: 1;
     position: absolute;
@@ -343,7 +343,7 @@ span.middleside {
     left: 50%;
     transform: translate(-50%, -50%);
 }
-
+  
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
@@ -377,6 +377,7 @@ span.middleside {
     grid-template-columns: repeat(2, 1fr);
     grid-gap: 32px;
     grid-auto-flow: column;
+    max-height: 97vh;
 }
 
 .annotation-adjacent, .selection-adjacent {
@@ -425,7 +426,7 @@ span.middleside {
 /* span#target-sentence {
     line-height: 1.7;
     font-size: 10.5pt;
-}
+} 
 .edit-box {
     width: 165px;
 }
@@ -451,3 +452,4 @@ span.middleside {
 .column-severity label {
     padding: 6px !important;
 } */
+

--- a/src/components/hitbox/HitBox.vue
+++ b/src/components/hitbox/HitBox.vue
@@ -181,6 +181,9 @@ export default {
         source_exists() {
             return this.hits_data && this.hits_data[this.current_hit - 1] && this.hits_data[this.current_hit - 1].source
         },
+        showAdjacent() {
+          return this.config.hasOwnProperty('display') && Object.values(this.config.display).includes('text-side-by-side') && this.source_exists() && this.target_exists()
+        },
         file_download() {
             handle_file_download(this.hits_data)
         },
@@ -232,7 +235,7 @@ export default {
                     <input type="file" id="upload-btn" @change="file_upload"/>
                     <label class="file-upload br-100 w2-5 h2-5 pointer" for="upload-btn" :class="{'disabled': config.disable && Object.values(config.disable).includes('upload')}"><i class="fa fa-arrow-up"></i></label>
                 </div>
-            </div>            
+            </div>
         </div>
         <div>
             <div class="ba b--black-80 br2 pa2">
@@ -251,20 +254,24 @@ export default {
                     <vue-markdown :source="hits_data[current_hit - 1].context" class="mt0 mb0" />
                 </div>
 
-                <div class="cf" v-if="source_exists()">
-                    <p class="fl f3 mt1 mb1 orig-sentence-header">
-                        <span class="f5">{{ config.interface_text.typology.source_label }}:</span>
-                    </p>
+                <div class="cf" v-if="source_exists()" />
+                <div :class="{'adjacent': showAdjacent() }">
+                    <div class="grid-child">
+                        <div class="cf" v-if="source_exists()">
+                            <p class="fl f3 mt0 mb1 orig-sentence-header">
+                                <span class="f5">{{ config.interface_text.typology.source_label }}:</span>
+                            </p>
+                        </div>
+                        <Sent sent_type="source" v-bind="$props" :remove_selected="remove_selected" />
+                    </div>
+
+                    <div class="grid-child">
+                        <p class="f3 mb1" v-if="target_exists()" :class="{'mt0': !source_exists() || showAdjacent() }">
+                            <span class="f5">{{ config.interface_text.typology.target_label }}:</span>
+                        </p>
+                        <Sent sent_type="target" v-bind="$props" :remove_selected="remove_selected" />
+                    </div>
                 </div>
-                
-                <Sent sent_type="source" v-bind="$props" :remove_selected="remove_selected" />
-
-                <p class="f3 mb1" v-if="target_exists()" :class="{'mt0': !source_exists()}">
-                    <span class="f5">{{ config.interface_text.typology.target_label }}:</span>
-                </p>
-
-                <Sent sent_type="target" v-bind="$props" :remove_selected="remove_selected" />
-
             </div>
         </div>
     </section>

--- a/src/components/hitbox/HitBox.vue
+++ b/src/components/hitbox/HitBox.vue
@@ -235,7 +235,7 @@ export default {
                     <input type="file" id="upload-btn" @change="file_upload"/>
                     <label class="file-upload br-100 w2-5 h2-5 pointer" for="upload-btn" :class="{'disabled': config.disable && Object.values(config.disable).includes('upload')}"><i class="fa fa-arrow-up"></i></label>
                 </div>
-            </div>
+            </div>            
         </div>
         <div>
             <div class="ba b--black-80 br2 pa2">

--- a/src/components/pages/Interface.vue
+++ b/src/components/pages/Interface.vue
@@ -29,7 +29,7 @@
         hit_box_config: undefined,
         selected_state: undefined,
         annotating_edit_span: undefined,
-        
+
         set_hit: this.set_hit,
         set_hits_data: this.set_hits_data,
         set_edits_dict: this.set_edits_dict,
@@ -73,13 +73,13 @@
           let new_config;
           if (this.consumed_config.hasOwnProperty('consumed_config')) {
             new_config = _.cloneDeep(this.consumed_config.consumed_config)
-          } else if (this.consumed_config.hasOwnProperty('config')) { 
+          } else if (this.consumed_config.hasOwnProperty('config')) {
             new_config = _.cloneDeep(this.consumed_config.config)
           } else {
             new_config = _.cloneDeep(this.consumed_config)
           }
           this.config = new_config
-          
+
           if (this.config.template_label) {
             $('title').text(this.config.template_label);
           }
@@ -194,7 +194,7 @@
             }
 
             let light_color = tinycolor(color).lighten(25).toHexString();
-            
+
             css += `
               :root { --${edit.name}: ${color}; --${edit.name}-light: ${light_color}; }
               .border-${edit.name} { border-bottom: 3px solid ${color}; }
@@ -233,7 +233,7 @@
     updated() {
       $('#custom_style').html(`<style>${this.compile_style()}</style>`)
       $(`#circle-${this.current_hit}`).addClass('circle-active');
-    }, 
+    },
     mounted() {
       this.consume_data()
       this.consume_config()
@@ -243,11 +243,11 @@
       this.refresh_interface_edit()
     }
   }
-  
+
 </script>
 
 <template>
-  <div v-if="config != null" class="container w-65 mb0 card-body" v-bind:class="{ 'w-adjacent': isAdjacent() }">
+  <div v-if="config != null" class="container w-100 mb0 card-body" v-bind:class="{ 'w-adjacent': isAdjacent() }">
     <div class='custom_style' id='custom_style'>Custom style has not loaded!</div>
     <div v-if="highlight" class="tc f3 b mb3 mt3 adjudication-highlight">
       {{ config.interface_text.adjudication.highlight_label }}

--- a/src/components/pages/Interface.vue
+++ b/src/components/pages/Interface.vue
@@ -29,7 +29,7 @@
         hit_box_config: undefined,
         selected_state: undefined,
         annotating_edit_span: undefined,
-
+        
         set_hit: this.set_hit,
         set_hits_data: this.set_hits_data,
         set_edits_dict: this.set_edits_dict,
@@ -73,13 +73,13 @@
           let new_config;
           if (this.consumed_config.hasOwnProperty('consumed_config')) {
             new_config = _.cloneDeep(this.consumed_config.consumed_config)
-          } else if (this.consumed_config.hasOwnProperty('config')) {
+          } else if (this.consumed_config.hasOwnProperty('config')) { 
             new_config = _.cloneDeep(this.consumed_config.config)
           } else {
             new_config = _.cloneDeep(this.consumed_config)
           }
           this.config = new_config
-
+          
           if (this.config.template_label) {
             $('title').text(this.config.template_label);
           }
@@ -194,7 +194,7 @@
             }
 
             let light_color = tinycolor(color).lighten(25).toHexString();
-
+            
             css += `
               :root { --${edit.name}: ${color}; --${edit.name}-light: ${light_color}; }
               .border-${edit.name} { border-bottom: 3px solid ${color}; }
@@ -233,7 +233,7 @@
     updated() {
       $('#custom_style').html(`<style>${this.compile_style()}</style>`)
       $(`#circle-${this.current_hit}`).addClass('circle-active');
-    },
+    }, 
     mounted() {
       this.consume_data()
       this.consume_config()
@@ -243,11 +243,11 @@
       this.refresh_interface_edit()
     }
   }
-
+  
 </script>
 
 <template>
-  <div v-if="config != null" class="container w-100 mb0 card-body" v-bind:class="{ 'w-adjacent': isAdjacent() }">
+  <div v-if="config != null" class="container w-65 mb0 card-body" v-bind:class="{ 'w-adjacent': isAdjacent() }">
     <div class='custom_style' id='custom_style'>Custom style has not loaded!</div>
     <div v-if="highlight" class="tc f3 b mb3 mt3 adjudication-highlight">
       {{ config.interface_text.adjudication.highlight_label }}

--- a/src/components/pages/Interface.vue
+++ b/src/components/pages/Interface.vue
@@ -247,7 +247,7 @@
 </script>
 
 <template>
-  <div v-if="config != null" class="container w-65 mb0 card-body" v-bind:class="{ 'w-adjacent': isAdjacent() }">
+  <div v-if="config != null" class="container mb0 card-body" v-bind:class="{ 'w-100 w-adjacent': isAdjacent(), 'w-65': !isAdjacent() }">
     <div class='custom_style' id='custom_style'>Custom style has not loaded!</div>
     <div v-if="highlight" class="tc f3 b mb3 mt3 adjudication-highlight">
       {{ config.interface_text.adjudication.highlight_label }}

--- a/src/components/viewer/EditList.vue
+++ b/src/components/viewer/EditList.vue
@@ -97,7 +97,7 @@ export default {
             } else if (this.getEditConfig(category)['type'] == 'composite') {
                 let new_edit_span = ""
                 let light = ""
-                
+
                 new_edit_span += `<span class="edit-type txt-${category}${light} f3"> (</span>`;
                 for (let j = 0; j < annotating_span['constituent_edits'].length; j++) {
                     const constituent_edit = annotating_span['constituent_edits'][j];
@@ -118,7 +118,7 @@ export default {
                     new_edit_span += `<span class="pa1 edit-text br-pill-ns txt-${category} border-${category}-all ${category}_below">
                         &nbsp${source_sentence.substring(span_idx[0], span_idx[1])}&nbsp</span>`
                     this.set_annotating_edit_span(new_edit_span, 'source')
-                } 
+                }
 
                 if (annotating_span.hasOwnProperty('output_idx')) {
                     let span_idx = annotating_span['output_idx'][0]
@@ -135,7 +135,7 @@ export default {
             const real_id = parseInt(e.target.dataset.id.split("-")[1])
             const category = e.target.dataset.category
             const old_edits_list = this.hits_data[this.current_hit - 1]["edits"]
-            
+
             let new_edits_list = []
             for (const old_edit of old_edits_list) {
                 if (old_edit["id"] == real_id && old_edit["category"] == category) {
@@ -157,11 +157,14 @@ export default {
                 return entry['name'] === category;
             });
         },
+        linesDisabled() {
+          return this.config.hasOwnProperty('display') && Object.values(this.config.display).includes('disable-lines')
+        },
         getAnnotationHtml(ann_config, ann) {
             if (ann == null) {
                 return '';
             }
-            
+
             let ann_html = ''
             for (let edit_ann_type of ann_config) {
                 let ann_type_name = edit_ann_type['name']
@@ -203,8 +206,8 @@ export default {
                         if (edit_ann_type.hasOwnProperty('options')) {
                             ann_html += this.getAnnotationHtml(edit_ann_type['options'], ann[ann_type_name])
                         }
-                    }                            
-                } 
+                    }
+                }
             }
             return ann_html
         },
@@ -283,7 +286,7 @@ export default {
                 new_html += `
                     <div class='cf'>
                         <div class="fl w-80 edit">`;
-                
+
                 // Render edit
                 const edit_config = this.getEditConfig(key)
                 const edit_label = edit_config.label ? edit_config.label : key
@@ -295,7 +298,7 @@ export default {
                             <span class="pa1 edit-text br-pill-ns txt-${key}${light} border-${key}${light}-all ${key}_below" data-id="${key}-${i}" data-category="${key}">
                                 &nbsp<i class="fa-solid ${composite_icon}"></i>&nbsp</span>
                                 <span class="edit-type txt-${key}${light} f3"> (</span>`;
-                    
+
                     for (let j = 0; j < edit['constituent_edits'].length; j++) {
                         const constituent_edit = edit['constituent_edits'][j];
                         const constituent_key = constituent_edit['category'];
@@ -311,9 +314,9 @@ export default {
                 } else {
                     new_html += this.render_edit_text(edit, i, key, light)
                 }
-                
-                if (!this.config.disable || !Object.values(this.config.disable).includes('annotation')) { 
-                    new_html += ` : `; 
+
+                if (!this.config.disable || !Object.values(this.config.disable).includes('annotation')) {
+                    new_html += ` : `;
                 }
 
                 // Render annotation
@@ -343,7 +346,7 @@ export default {
                     </div>
                 </div>`;
             }
-            
+
             this.set_edits_dict(hit_edits);
             this.edits_html = new_html;
         },
@@ -364,7 +367,7 @@ export default {
         draw_lines: function() {
             // There's some latency in this function, the locking ensures no line references are lost
             if (this.line_locked) { return }
-            if (!this.config.hasOwnProperty('edits')) { return }
+            if (!this.config.hasOwnProperty('edits') || this.linesDisabled()) { return }
             this.line_locked = true
 
             try {
@@ -422,7 +425,7 @@ export default {
                             $(`.${key}.target_span[data-id='${key}-${id}']`)[0],
                             line_config
                         )
-                        
+
                         // My attempt to fix line drawing in builder via mutation observers
                         // var draw_lines = this.draw_lines
                         // const targetElement = $(`.${key}.source_span[data-id='${key}-${id}']`)[0]
@@ -549,5 +552,5 @@ export default {
 </script>
 
 <template>
-    <component :is="get_edits_html"></component> 
+    <component :is="get_edits_html"></component>
 </template>

--- a/src/components/viewer/EditList.vue
+++ b/src/components/viewer/EditList.vue
@@ -315,7 +315,7 @@ export default {
                     new_html += this.render_edit_text(edit, i, key, light)
                 }
                 
-                if (!this.config.disable || !Object.values(this.config.disable).includes('annotation')) {
+                if (!this.config.disable || !Object.values(this.config.disable).includes('annotation')) { 
                     new_html += ` : `; 
                 }
 

--- a/src/components/viewer/EditList.vue
+++ b/src/components/viewer/EditList.vue
@@ -314,9 +314,9 @@ export default {
                 } else {
                     new_html += this.render_edit_text(edit, i, key, light)
                 }
-
+                
                 if (!this.config.disable || !Object.values(this.config.disable).includes('annotation')) {
-                    new_html += ` : `;
+                    new_html += ` : `; 
                 }
 
                 // Render annotation

--- a/src/components/viewer/EditList.vue
+++ b/src/components/viewer/EditList.vue
@@ -97,7 +97,7 @@ export default {
             } else if (this.getEditConfig(category)['type'] == 'composite') {
                 let new_edit_span = ""
                 let light = ""
-
+                
                 new_edit_span += `<span class="edit-type txt-${category}${light} f3"> (</span>`;
                 for (let j = 0; j < annotating_span['constituent_edits'].length; j++) {
                     const constituent_edit = annotating_span['constituent_edits'][j];
@@ -118,7 +118,7 @@ export default {
                     new_edit_span += `<span class="pa1 edit-text br-pill-ns txt-${category} border-${category}-all ${category}_below">
                         &nbsp${source_sentence.substring(span_idx[0], span_idx[1])}&nbsp</span>`
                     this.set_annotating_edit_span(new_edit_span, 'source')
-                }
+                } 
 
                 if (annotating_span.hasOwnProperty('output_idx')) {
                     let span_idx = annotating_span['output_idx'][0]
@@ -135,7 +135,7 @@ export default {
             const real_id = parseInt(e.target.dataset.id.split("-")[1])
             const category = e.target.dataset.category
             const old_edits_list = this.hits_data[this.current_hit - 1]["edits"]
-
+            
             let new_edits_list = []
             for (const old_edit of old_edits_list) {
                 if (old_edit["id"] == real_id && old_edit["category"] == category) {
@@ -164,7 +164,7 @@ export default {
             if (ann == null) {
                 return '';
             }
-
+            
             let ann_html = ''
             for (let edit_ann_type of ann_config) {
                 let ann_type_name = edit_ann_type['name']
@@ -206,8 +206,8 @@ export default {
                         if (edit_ann_type.hasOwnProperty('options')) {
                             ann_html += this.getAnnotationHtml(edit_ann_type['options'], ann[ann_type_name])
                         }
-                    }
-                }
+                    }                            
+                } 
             }
             return ann_html
         },
@@ -286,7 +286,7 @@ export default {
                 new_html += `
                     <div class='cf'>
                         <div class="fl w-80 edit">`;
-
+                
                 // Render edit
                 const edit_config = this.getEditConfig(key)
                 const edit_label = edit_config.label ? edit_config.label : key
@@ -298,7 +298,7 @@ export default {
                             <span class="pa1 edit-text br-pill-ns txt-${key}${light} border-${key}${light}-all ${key}_below" data-id="${key}-${i}" data-category="${key}">
                                 &nbsp<i class="fa-solid ${composite_icon}"></i>&nbsp</span>
                                 <span class="edit-type txt-${key}${light} f3"> (</span>`;
-
+                    
                     for (let j = 0; j < edit['constituent_edits'].length; j++) {
                         const constituent_edit = edit['constituent_edits'][j];
                         const constituent_key = constituent_edit['category'];
@@ -346,7 +346,7 @@ export default {
                     </div>
                 </div>`;
             }
-
+            
             this.set_edits_dict(hit_edits);
             this.edits_html = new_html;
         },
@@ -425,7 +425,7 @@ export default {
                             $(`.${key}.target_span[data-id='${key}-${id}']`)[0],
                             line_config
                         )
-
+                        
                         // My attempt to fix line drawing in builder via mutation observers
                         // var draw_lines = this.draw_lines
                         // const targetElement = $(`.${key}.source_span[data-id='${key}-${id}']`)[0]
@@ -552,5 +552,5 @@ export default {
 </script>
 
 <template>
-    <component :is="get_edits_html"></component>
+    <component :is="get_edits_html"></component> 
 </template>


### PR DESCRIPTION
When working with long texts a horizontal layout could be preferred to minimize scrolling. This PR adds a `text-side-by-side` display option which can be combined with the existing `side-by-side` option.

**Example:**
<img width="1680" alt="Screenshot 2023-09-11 at 15 59 41" src="https://github.com/davidheineman/thresh/assets/12009072/2ace6be1-6b0c-4593-b995-29177a63bd03">