### PR TITLE
Render sents with <pre> to support \n newlines

### DIFF
--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -20,6 +20,11 @@
     margin-right: auto!important;
 }
 
+.selection-area {
+    white-space: pre-line;
+    margin: 0;
+}
+
 .w-13 {
     width: 13%;
 }

--- a/src/components/hitbox/SourceSent.vue
+++ b/src/components/hitbox/SourceSent.vue
@@ -86,9 +86,9 @@ export default {
 
             $('#source-sentence').addClass(`select-color-${selected_category}`)
 
-            let split_chars = [' ']
+            let split_chars = [' ', '\n']
             if (this.config.tokenization && this.config.tokenization == 'tokenized') {
-                split_chars = ['Ġ', ' ']
+                split_chars = ['Ġ', ' ', '\n']
             }
             
             let txt = this.hits_data[this.current_hit - 1].source

--- a/src/components/hitbox/SourceSent.vue
+++ b/src/components/hitbox/SourceSent.vue
@@ -159,7 +159,7 @@ export default {
     computed: {
         get_source_html() {
             return {
-                template: `<span @mousedown='deselect_source_html' @mouseup='select_source_html' id="source-sentence" class="f4 lh-paras">${this.source_html}</span>`,
+                template: `<pre @mousedown='deselect_source_html' @mouseup='select_source_html' id="source-sentence" class="f4 lh-paras sans-serif" style="white-space: pre-line;">${this.source_html}</pre>`,
                 methods: {
                     select_source_html: this.select_source_html,
                     deselect_source_html: this.deselect_source_html,

--- a/src/components/hitbox/SourceSent.vue
+++ b/src/components/hitbox/SourceSent.vue
@@ -159,7 +159,7 @@ export default {
     computed: {
         get_source_html() {
             return {
-                template: `<pre @mousedown='deselect_source_html' @mouseup='select_source_html' id="source-sentence" class="f4 lh-paras sans-serif" style="white-space: pre-line;">${this.source_html}</pre>`,
+                template: `<pre @mousedown='deselect_source_html' @mouseup='select_source_html' id="source-sentence" class="f4 lh-paras sans-serif selection-area">${this.source_html}</pre>`,
                 methods: {
                     select_source_html: this.select_source_html,
                     deselect_source_html: this.deselect_source_html,

--- a/src/components/hitbox/TargetSent.vue
+++ b/src/components/hitbox/TargetSent.vue
@@ -162,7 +162,7 @@ export default {
     computed: {
         get_target_html() {
             return {
-                template: ` <span @mousedown='deselect_target_html' @mouseup='select_target_html' id="target-sentence" class="f4 lh-paras"> ${ this.target_html } </span> `,
+                template: ` <pre @mousedown='deselect_target_html' @mouseup='select_target_html' id="target-sentence" class="f4 lh-paras sans-serif" style="white-space: pre-line;"> ${ this.target_html } </pre> `,
                 methods: {
                         select_target_html: this.select_target_html,
                         deselect_target_html: this.deselect_target_html,

--- a/src/components/hitbox/TargetSent.vue
+++ b/src/components/hitbox/TargetSent.vue
@@ -91,9 +91,9 @@ export default {
 
             $('#target-sentence').addClass(`select-color-${selected_category}`)
 
-            let split_chars = [' ']
+            let split_chars = [' ', '\n']
             if (this.config.tokenization && this.config.tokenization == 'tokenized') {
-                split_chars = ['Ġ', ' ']
+                split_chars = ['Ġ', ' ', '\n']
             }
             let txt = this.hits_data[this.current_hit - 1].target
 

--- a/src/components/hitbox/TargetSent.vue
+++ b/src/components/hitbox/TargetSent.vue
@@ -162,7 +162,7 @@ export default {
     computed: {
         get_target_html() {
             return {
-                template: ` <pre @mousedown='deselect_target_html' @mouseup='select_target_html' id="target-sentence" class="f4 lh-paras sans-serif" style="white-space: pre-line;"> ${ this.target_html } </pre> `,
+                template: `<pre @mousedown='deselect_target_html' @mouseup='select_target_html' id="target-sentence" class="f4 lh-paras sans-serif selection-area"> ${ this.target_html } </pre> `,
                 methods: {
                         select_target_html: this.select_target_html,
                         deselect_target_html: this.deselect_target_html,


### PR DESCRIPTION
Minor change to render newlines in the source/target sentence. This is useful for annotating multi-paragraph text. We earlier tried replacing `\n` with `<br />` but that caused offset issues while highlighting. 

Edits can also cross newlines
<img width="759" alt="Screenshot 2023-09-14 at 16 56 27" src="https://github.com/davidheineman/thresh/assets/12009072/f941849b-c163-4e9c-97fd-16a39d09a1a0">
