### PR TITLE
Allow configuration of basePath for deployment

### DIFF
--- a/src/assets/js/file-util.js
+++ b/src/assets/js/file-util.js
@@ -59,3 +59,7 @@ export function download_config(file_path) {
         .then(response => response.text())
         .then(r => {return r});
 }
+
+export function joinPaths(path1, path2) {
+    return path1.replace(/\/$/, '') + '/' + path2.replace(/^\//, '');
+}

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -3,7 +3,7 @@
     import Deploy from "../builder/Deploy.vue";
     import Cite from "../builder/Cite.vue";
 
-    import { download_data, download_config, get_file_path } from "../../assets/js/file-util.js";
+    import { download_data, download_config, get_file_path, joinPaths } from "../../assets/js/file-util.js";
 
     import jsyaml from 'js-yaml';
     import * as monaco from 'monaco-editor'
@@ -26,6 +26,8 @@
 </script>
 
 <script>
+
+
 export default {
     data() {
         return {
@@ -203,11 +205,11 @@ export default {
             const basePath = import.meta.env.BASE_URL;
             let template, file_path
             if (!template_arg.includes('http')) {
-                template = `${basePath}/templates/${template_arg}.yml`
-                file_path = `${basePath}/data/${template_arg}.json`
+                template = joinPaths(basePath, `/templates/${template_arg}.yml`)
+                file_path = joinPaths(basePath, `/data/${template_arg}.json`)
             } else {
                 template = template_arg
-                file_path = `${basePath}/data/demo/start.json`
+                file_path = joinPaths(basePath, `/data/demo/start.json`)
             }
             
             this.selectedOption = template

--- a/src/components/pages/Builder.vue
+++ b/src/components/pages/Builder.vue
@@ -200,13 +200,14 @@ export default {
 
             template_arg = template_arg.replace('demo_', 'demo/')
             
+            const basePath = import.meta.env.BASE_URL;
             let template, file_path
             if (!template_arg.includes('http')) {
-                template = `/templates/${template_arg}.yml`
-                file_path = `/data/${template_arg}.json`
+                template = `${basePath}/templates/${template_arg}.yml`
+                file_path = `${basePath}/data/${template_arg}.json`
             } else {
                 template = template_arg
-                file_path = `/data/demo/start.json`
+                file_path = `${basePath}/data/demo/start.json`
             }
             
             this.selectedOption = template

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { createApp, h } from "vue/dist/vue.esm-bundler.js"
 import { createRouter, createWebHistory } from 'vue-router'
 import App from './App.vue'
+import { joinPaths  } from "./assets/js/file-util";
 
 // Add global imports
 import './assets/js/font-awesome.min.js';
@@ -46,15 +47,15 @@ var hfParam = params.get("hf");
 
 const basePath = import.meta.env.BASE_URL;
 const routes = [
-    { path: `${basePath}/`, component: (iParam || ghParam || hfParam) ? () => import("./components/pages/Viewer.vue") : () => import("./components/pages/Builder.vue") },
-    { path: `${basePath}/demo`, component: () => import("./components/pages/Builder.vue") },
-    { path: `${basePath}/custom`, props: () => ({ injection: true }), component: () => import("./components/pages/Viewer.vue") },
-    { path: `${basePath}/annotate`, props: () => ({ serverless: true }), component: () => import("./components/pages/Viewer.vue") }
+    { path: joinPaths(basePath, '/'), component: (iParam || ghParam || hfParam) ? () => import("./components/pages/Viewer.vue") : () => import("./components/pages/Builder.vue") },
+    { path: joinPaths(basePath, '/demo'), component: () => import("./components/pages/Builder.vue") },
+    { path: joinPaths(basePath, '/custom'), props: () => ({ injection: true }), component: () => import("./components/pages/Viewer.vue") },
+    { path: joinPaths(basePath, '/annotate'), props: () => ({ serverless: true }), component: () => import("./components/pages/Viewer.vue") }
 ]
 
 for (const template of templates) {
     const template_path = template.path
-    routes.push({ path: `${basePath}/${template.path}`, props: () => ({ template_path: template_path }), component: () => import("./components/pages/Viewer.vue") })
+    routes.push({ path: joinPaths(basePath, `/${template.path}`), props: () => ({ template_path: template_path }), component: () => import("./components/pages/Viewer.vue") })
 }
 
 const router = createRouter({

--- a/src/main.js
+++ b/src/main.js
@@ -44,16 +44,17 @@ var iParam = params.get("i");
 var ghParam = params.get("gh");
 var hfParam = params.get("hf");
 
+const basePath = import.meta.env.BASE_URL;
 const routes = [
-    { path: '/', component: (iParam || ghParam || hfParam) ? () => import("./components/pages/Viewer.vue") : () => import("./components/pages/Builder.vue") },
-    { path: `/demo`, component: () => import("./components/pages/Builder.vue") },
-    { path: '/custom', props: () => ({ injection: true }), component: () => import("./components/pages/Viewer.vue") },
-    { path: '/annotate', props: () => ({ serverless: true }), component: () => import("./components/pages/Viewer.vue") }
+    { path: `${basePath}/`, component: (iParam || ghParam || hfParam) ? () => import("./components/pages/Viewer.vue") : () => import("./components/pages/Builder.vue") },
+    { path: `${basePath}/demo`, component: () => import("./components/pages/Builder.vue") },
+    { path: `${basePath}/custom`, props: () => ({ injection: true }), component: () => import("./components/pages/Viewer.vue") },
+    { path: `${basePath}/annotate`, props: () => ({ serverless: true }), component: () => import("./components/pages/Viewer.vue") }
 ]
 
 for (const template of templates) {
     const template_path = template.path
-    routes.push({ path: `/${template.path}`, props: () => ({ template_path: template_path }), component: () => import("./components/pages/Viewer.vue") })
+    routes.push({ path: `${basePath}/${template.path}`, props: () => ({ template_path: template_path }), component: () => import("./components/pages/Viewer.vue") })
 }
 
 const router = createRouter({

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,8 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
+const baseUrl = process.env.VITE_BASE_URL || '/';
+
 export default defineConfig({
   plugins: [
     vue()
@@ -12,5 +14,5 @@ export default defineConfig({
       vue$: 'vue/dist/vue.esm-bundler.js',
     }
   },
-  base: process.env.NODE_ENV === 'production' ? '/' : '/',
+  base: process.env.NODE_ENV === 'production' ? baseUrl : '/',
 })


### PR DESCRIPTION
I tried deploying onto a different base path, but the routes would not load. This propagates the vite base path to the router which does the trick.

Build as:

```
export VITE_BASE_URL=/the/path/
npm run build
```